### PR TITLE
Add support for Erchang F68

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="ping">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,17 +4,16 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="PLATFORM" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/ping" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
-        <option name="useQualifiedModuleNames" value="true" />
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="org.jetbrains.annotations.Nullable" />

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -3,6 +3,14 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/README.md
+++ b/README.md
@@ -4,6 +4,29 @@ Low-cost sonar, using an Erchang Fish Finder.
 
 <img src="Screenshot_20201229-120351.png" alt="screenshot" width="250"/> <img src="Device.png" alt="device" width="250"/>
 
+## Fork
+
+This is a fork of https://github.com/cdot/Ping
+
+I found the original repo and bought a similar sonar. However, I received a different model with a slightly different protocol.
+
+This fork is to add support for the [Erchang F68 on AliExpress](https://www.aliexpress.com/item/1005005631782287.html). About A$80 at the time (2024).
+
+The official app [Erchang F68 on Play Store](https://play.google.com/store/apps/details?id=com.appxdx.erchangfish&hl=en_AU&gl=US) was used to understand the protocol.
+
+The main protocol differences is that F68 has 20 bytes for the data, and some flags seems to be omitted compared to the original.
+
+The depth reading has been tested in the ocean and seems accurate up to 50 meters. The fish depth has not been calibrated.
+
+To distinguish this version from the original code, a device type has been added to switch between different code paths:
+```
+    public static final BtDeviceType BT_DEVICE_TYPE = BtDeviceType.F68;
+```
+
+...
+
+> The text below is from the original fork
+
 ## Usage
 To install, click on the [Releases](https://github.com/cdot/Ping/releases) link on the 
 right of the screen to see the binary releases. Download the APK file to your device and open it to install. Android

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,11 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -20,7 +20,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/ping/src/main/java/com/cdot/ping/DiscoveryFragment.java
+++ b/ping/src/main/java/com/cdot/ping/DiscoveryFragment.java
@@ -200,8 +200,8 @@ public class DiscoveryFragment extends Fragment {
             // This means _paired_ and NOT _bonded_; see https://piratecomm.wordpress.com/2014/01/19/ble-pairing-vs-bonding/
             Log.d(TAG, "onScanResult " + device.getAddress() + " " + device.getName() + " pairing state " + device.getBondState());
             // DIY filtering, because the system code doesn't work (see above)
-            List<ParcelUuid> uuids = result.getScanRecord().getServiceUuids();
-            if (uuids != null && uuids.contains(new ParcelUuid(SonarBluetooth.SERVICE_UUID))) {
+            // Instead of looking for SonarBluetooth.SERVICE_UUID as original code dit, just look for the device name
+            if (SonarBluetooth.BT_DEVICE_NAME.equals(device.getName())) {
                 if (mAutoConnect) {
                     // First device that offers the service we want. Fingers crossed!
                     getMainActivity().switchToConnectedFragment(device);

--- a/ping/src/main/java/com/cdot/ping/MainActivity.java
+++ b/ping/src/main/java/com/cdot/ping/MainActivity.java
@@ -34,6 +34,7 @@ import android.os.Bundle;
 import android.os.IBinder;
 import android.os.Parcelable;
 import android.util.Log;
+import android.view.WindowManager;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -154,6 +155,11 @@ public class MainActivity extends AppCompatActivity {
         setContentView(mBinding.mainActivityL);
 
         getPermissions();
+        keepScreenOn();
+    }
+
+    private void keepScreenOn() {
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     }
 
     // See https://developer.android.com/guide/components/activities/activity-lifecycle

--- a/ping/src/main/java/com/cdot/ping/samplers/SonarBluetooth.java
+++ b/ping/src/main/java/com/cdot/ping/samplers/SonarBluetooth.java
@@ -56,6 +56,9 @@ public class SonarBluetooth implements ConnectionObserver {
     public static final int BT_STATE_DISCONNECTING = 4;
     public static final int BT_STATE_CONNECT_FAILED = 5;
 
+
+    public static final String BT_DEVICE_NAME = "Erchang Fish";
+
     // UUIDs
     public static final UUID SERVICE_UUID = UUID.fromString("0000fff0-0000-1000-8000-00805f9b34fb");
     public static final UUID SAMPLE_CHARACTERISTIC_UUID = UUID.fromString("0000fff1-0000-1000-8000-00805f9b34fb");

--- a/ping/src/main/res/values/strings.xml
+++ b/ping/src/main/res/values/strings.xml
@@ -122,7 +122,7 @@
     <string name="val_sample_rate">Rate: %1$.2gHz</string>
     <string name="val_strength">Strength %1$d%%</string>
     <string name="val_temperature">Temperature: %1$.2g°C</string>
-    <string name="default_device_name">Unspecified Bluetooth Device</string>
+    <string name="default_device_name">Unspecified</string>
     <string name="write_gpx_failed">Could not write GPX file</string>
     <string name="write_gpx_OK">GPX data written</string>
     <string name="menuitem_write_gpx">GPX</string>


### PR DESCRIPTION
The protocol for the device Erchang F68 is slightly different. This adds support for it and updates the project to have a working build.

This PR includes
- Add a hardcoded `BT_DEVICE_TYPE` that sets how to handle the bluetooth device.
- Changes to connect to device by name "Erchang Fish" instead of a service uuid.
- Added keep screen on.
- Gradle upgrade.
- Replace jcenter with mavenCentral for dependencies.
- Make the default_device_name shorter to avoid layout issues.
- Depth for F68 has been tested, not all the other data points.